### PR TITLE
except and fstring done the usual way

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -114,8 +114,8 @@ async def send_quote(pre: str = "Quote", title: Optional[str] = None, which: Opt
     logger.info(f"Sending quote from {quote.submitter}: {quote_text}")
     try:
         await client.get_channel(CHANNEL).send(embed = embedVar)
-    except e:
-        logger.info(f"Error sending quote : {str(e)}")
+    except Exception as e:
+        logger.info(f"Error sending quote : {e}")
     finally:
         logger.info(f"Quote sent successfully")
 


### PR DESCRIPTION
Just a small change. F-strings automatically do conversion to string, and naming exceptions is best done using `as` rather than implicitly. I'll be honest, it's mostly to make my linter complain less.