### PR TITLE
Default should be one that doesn't exist

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -241,7 +241,7 @@ Quote {i}/{len(quotes)}, Submitted by {quote.submitter}"""
 
 
 @client.event
-async def test_quote(which: str = "pre-toml-255", log: str = "test_quote") -> None:
+async def test_quote(which: str = "<testing>", log: str = "test_quote") -> None:
     """Send our default testing quote, or another one of your choice, marked up so we can tell."""
     await send_quote(pre="Testing", title="Testing the Swack", which=which, log=log)
 


### PR DESCRIPTION
Behaviour is that any specific quote asked for that *doesn't* exist gets replaced with the default testing one, so we shouldn't use an existing one as the default.